### PR TITLE
Add compatibility to Chrome v80+

### DIFF
--- a/Chrome Password Recovery.go
+++ b/Chrome Password Recovery.go
@@ -18,7 +18,12 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
-
+	"strings"
+	"encoding/json"
+	"io/ioutil"
+	"encoding/base64"
+	"crypto/aes"
+	"crypto/cipher"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -30,6 +35,8 @@ var (
 	procLocalFree   = dllkernel32.NewProc("LocalFree")
 
 	dataPath string = os.Getenv("USERPROFILE") + "\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Login Data"
+	localStatePath string = os.Getenv("USERPROFILE") + "\\AppData\\Local\\Google\\Chrome\\User Data\\Local State"
+	masterKey []byte 
 )
 
 type DATA_BLOB struct {
@@ -111,17 +118,53 @@ func checkFileExist(filePath string) bool {
 	}
 }
 
+
+func getMasterKey() ([]byte,error){
+
+	var masterKey []byte
+
+	// Get the master key
+	// The master key is the key with which chrome encode the passwords but it has some suffixes and we need to work on it
+	jsonFile, err := os.Open(localStatePath) // The rough key is stored in the Local State File which is a json file
+	if err != nil {
+	    return masterKey,err
+	}
+
+	defer jsonFile.Close()
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+	    return masterKey,err
+	}
+	var result map[string]interface{}
+	json.Unmarshal([]byte(byteValue), &result)
+	roughKey := result["os_crypt"].(map[string]interface{})["encrypted_key"].(string) // Found parsing the json in it
+	decodedKey, err := base64.StdEncoding.DecodeString(roughKey)// It's stored in Base64 so.. Let's decode it
+	stringKey := string(decodedKey) 
+	stringKey = strings.Trim(stringKey, "DPAPI") // The key is encrypted using the windows DPAPI method and signed with it. the key looks like "DPAPI05546sdf879z456..." Let's Remove DPAPI.
+	
+	masterKey,err = Decrypt([]byte(stringKey)) // Decrypt the key using the dllcrypt32 dll.
+	if err != nil{
+		return masterKey,err
+	}
+
+	return masterKey,nil
+
+}
+
 func main() {
 	//Check for Login Data file
 	if !checkFileExist(dataPath) {
 		os.Exit(0)
 	}
 
+	
 	//Copy Login Data file to temp location
 	err := copyFileToDirectory(dataPath, os.Getenv("APPDATA")+"\\tempfile.dat")
 	if err != nil {
 		log.Fatal(err)
 	}
+
 
 	//Open Database
 	db, err := sql.Open("sqlite3", os.Getenv("APPDATA")+"\\tempfile.dat")
@@ -147,14 +190,57 @@ func main() {
 			log.Fatal(err)
 		}
 		//Decrypt Passwords
-		pass, err := Decrypt([]byte(PASSWORD))
-		if err != nil {
-			log.Fatal(err)
+		if strings.HasPrefix(PASSWORD, "v10"){ // Means it's chrome 80 or higher
+			PASSWORD = strings.Trim(PASSWORD, "v10") 
+
+			//fmt.Println("Chrome Version is 80 or higher, switching to the AES 256 decrypt.")
+			if string(masterKey) != ""{
+				ciphertext := []byte(PASSWORD)
+				c, err := aes.NewCipher(masterKey)
+			    if err != nil {
+			    	
+			        fmt.Println(err)
+			    }
+			    gcm, err := cipher.NewGCM(c)
+			    if err != nil {
+			        fmt.Println(err)
+			    }
+			    nonceSize := gcm.NonceSize()
+			    if len(ciphertext) < nonceSize {
+			        fmt.Println(err)
+			    }
+
+			    nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+			    plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+			    if err != nil {
+			        fmt.Println(err)
+			    }
+			    if string(plaintext) != ""{
+			    	fmt.Println(URL," | ", USERNAME," | ", string(plaintext))
+			    	//fmt.Println(URL," | ", USERNAME," | ", "**DEMO**")
+
+			    }
+			}else{ // It the masterkey hasn't been requested yet, then gets it.
+				mkey,err := getMasterKey()
+				if err != nil{
+					fmt.Println(err)
+				}
+				masterKey = mkey
+			}
+		}else{ //Means it's chrome v. < 80
+			pass, err := Decrypt([]byte(PASSWORD))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if URL != "" && URL != "" && string(pass) != "" {
+				fmt.Println(URL, USERNAME, string(pass))
+			}
 		}
+
+		
 		//Check if no value, if none skip
-		if URL != "" && URL != "" && string(pass) != "" {
-			fmt.Println(URL, USERNAME, string(pass))
-		}
+		
 	}
 	err = rows.Err()
 	if err != nil {


### PR DESCRIPTION
Newest versions of Chrome, since ver. 80 include a new encryption process for the passwords described here : 
https://hothardware.com/news/google-chrome-aes-256-password-encryption-malware-devs

This pr takes into consideration the changes and can work with both 80+ versions of chrome as well as earlier.

Feel free to ask for more details